### PR TITLE
Remove trailing spaces and prevent recursive compilation using ng-att…

### DIFF
--- a/src/fixed-table-header.js
+++ b/src/fixed-table-header.js
@@ -10,113 +10,113 @@
 angular.module('fixed.table.header', []).directive('fixHead', fixHead);
 
 function fixHead($compile, $window) {
-  
+
   function compile(tElement) {
     var table = {
       clone: tElement.parent().clone().empty(),
       original: tElement.parent()
     };
-    
+
     var header = {
       clone: tElement.clone(),
       original: tElement
     };
-    
+
     // prevent recursive compilation
-    header.clone.removeAttr('fix-head').removeAttr('ng-if');
-    
+    header.clone.removeAttr('fix-head').removeAttr('ng-if').removeAttr('ng-attr-fix-head');
+
     table.clone.css({display: 'block', overflow: 'hidden'}).addClass('clone');
     header.clone.css('display', 'block');
     header.original.css('visibility', 'hidden');
-    
+
     return function postLink(scope) {
       var scrollContainer = table.original.parent();
-      
+
       // insert the element so when it is compiled it will link
       // with the correct scope and controllers
       header.original.after(header.clone);
-      
+
       $compile(table.clone)(scope);
       $compile(header.clone)(scope);
-      
+
       scrollContainer.parent()[0].insertBefore(table.clone.append(header.clone)[0], scrollContainer[0]);
-      
+
       scrollContainer.on('scroll', function () {
         // use CSS transforms to move the cloned header when the table is scrolled horizontally
         header.clone.css('transform', 'translate3d(' + -(scrollContainer.prop('scrollLeft')) + 'px, 0, 0)');
       });
-      
+
       function cells() {
         return header.clone.find('th').length;
       }
-      
+
       function getCells(node) {
         return Array.prototype.map.call(node.find('th'), function (cell) {
           return jQLite(cell);
         });
       }
-      
+
       function height() {
         return header.original.prop('clientHeight');
       }
-      
+
       function jQLite(node) {
         return angular.element(node);
       }
-      
+
       function marginTop(height) {
         table.original.css('marginTop', '-' + height + 'px');
       }
-      
+
       function updateCells() {
         var cells = {
           clone: getCells(header.clone),
           original: getCells(header.original)
         };
-        
+
         cells.clone.forEach(function (clone, index) {
           if(clone.data('isClone')) {
             return;
           }
-          
+
           // prevent duplicating watch listeners
           clone.data('isClone', true);
-          
+
           var cell = cells.original[index];
           var style = $window.getComputedStyle(cell[0]);
-          
+
           var getWidth = function () {
             return style.width;
           };
-          
+
           var setWidth = function () {
             marginTop(height());
             clone.css({minWidth: style.width, maxWidth: style.width});
           };
-          
+
           var listener = scope.$watch(getWidth, setWidth);
-          
+
           $window.addEventListener('resize', setWidth);
-          
+
           clone.on('$destroy', function () {
             listener();
             $window.removeEventListener('resize', setWidth);
           });
-          
+
           cell.on('$destroy', function () {
             clone.remove();
           });
         });
       }
-      
+
       scope.$watch(cells, updateCells);
-      
+
       header.original.on('$destroy', function () {
         header.clone.remove();
       });
     };
   }
-  
+
   return {
     compile: compile
   };


### PR DESCRIPTION
* Remove trailing spaces from source file
* Prevent recursive rendering when using conditional attr for fixed head. See docs for `ngAttr`-
 https://docs.angularjs.org/guide/interpolation#-ngattr-for-binding-to-arbitrary-attributes